### PR TITLE
Adding  `props.onClose()` on transfer, deposit, withdraw modals

### DIFF
--- a/examples/transfers/frontend/src/components/DepositModalWindow.tsx
+++ b/examples/transfers/frontend/src/components/DepositModalWindow.tsx
@@ -25,6 +25,7 @@ export function DepositModalWindow(props: ModalWindowProps) {
       console.log(data)
       setLoading(false)
       showSuccess('Deposit transaction sent successfully')
+      props.onClose() // Close the modal immediately after sending the transaction
     },
     onError: (error: any) => {
       setLoading(false)

--- a/examples/transfers/frontend/src/components/TransferModalWindow.tsx
+++ b/examples/transfers/frontend/src/components/TransferModalWindow.tsx
@@ -48,6 +48,7 @@ export function TransferModalWindow(props: ModalWindowProps) {
       console.log(data)
       setLoading(false)
       showSuccess('Transfer transaction sent successfully')
+      props.onClose() // Close the modal immediately after sending the transaction
     },
     onError: (error: any) => {
       setLoading(false)

--- a/examples/transfers/frontend/src/components/WithdrawModalWindow.tsx
+++ b/examples/transfers/frontend/src/components/WithdrawModalWindow.tsx
@@ -19,6 +19,7 @@ export function WithdrawModalWindow(props: ModalWindowProps) {
       console.log(data)
       setLoading(false)
       showSuccess('Withdraw transaction sent successfully')
+      props.onClose() // Close the modal immediately after sending the transaction
     },
     onError: (error: any) => {
       setLoading(false)


### PR DESCRIPTION
This PR adds a simple       `props.onClose()` to close the modals after success 