### PR TITLE
feat: add pay amount field to tx_execute

### DIFF
--- a/crates/cli/src/handler/handshake.rs
+++ b/crates/cli/src/handler/handshake.rs
@@ -56,7 +56,7 @@ async fn handshake(args: HandshakeRequest, config: Config) -> Result<String> {
                 2000000,
                 &config.tx_sender,
                 json!(res),
-                "11000untrn",
+                "0untrn"
             )
             .await
             .map_err(|err| eyre!(Box::new(err)))?// TODO: change
@@ -106,7 +106,7 @@ async fn handshake(args: HandshakeRequest, config: Config) -> Result<String> {
                 2000000,
                 &config.tx_sender,
                 json!(res),
-                "11000untrn",
+                "0untrn"
             )
             .await
             .map_err(|err| eyre!(Box::new(err)))? // todo change

--- a/crates/utils/cw-client/src/cli.rs
+++ b/crates/utils/cw-client/src/cli.rs
@@ -152,9 +152,13 @@ impl CwClient for CliClient {
         gas: u64,
         sender: &str,
         msg: M,
-        fees: &str,
         pay_amount: &str,
     ) -> Result<String, Self::Error> {
+        let gas_amount = match gas {
+            0 => "auto",
+            _ => &gas.to_string(),
+        };
+        
         let mut command = self.new_command()?;
         let command = command
             .args(["--node", self.url.as_str()])
@@ -162,8 +166,9 @@ impl CwClient for CliClient {
             .args(["tx", "wasm"])
             .args(["execute", contract.as_ref(), &msg.to_string()])
             .args(["--amount", pay_amount])
-            .args(["--gas", &gas.to_string()])
-            .args(["--fees", fees])
+            .args(["--gas", gas_amount])
+            .args(["--gas-adjustment", "1.3"])
+            .args(["--gas-prices", "0.025untrn"])
             .args(["--from", sender])
             .args(["--output", "json"])
             .arg("-y");

--- a/crates/utils/cw-client/src/cli.rs
+++ b/crates/utils/cw-client/src/cli.rs
@@ -158,7 +158,7 @@ impl CwClient for CliClient {
             0 => "auto",
             _ => &gas.to_string(),
         };
-        
+
         let mut command = self.new_command()?;
         let command = command
             .args(["--node", self.url.as_str()])

--- a/crates/utils/cw-client/src/cli.rs
+++ b/crates/utils/cw-client/src/cli.rs
@@ -153,6 +153,7 @@ impl CwClient for CliClient {
         sender: &str,
         msg: M,
         fees: &str,
+        pay_amount: &str,
     ) -> Result<String, Self::Error> {
         let mut command = self.new_command()?;
         let command = command
@@ -160,6 +161,7 @@ impl CwClient for CliClient {
             .args(["--chain-id", chain_id.as_ref()])
             .args(["tx", "wasm"])
             .args(["execute", contract.as_ref(), &msg.to_string()])
+            .args(["--amount", pay_amount])
             .args(["--gas", &gas.to_string()])
             .args(["--fees", fees])
             .args(["--from", sender])

--- a/crates/utils/cw-client/src/grpc.rs
+++ b/crates/utils/cw-client/src/grpc.rs
@@ -89,6 +89,7 @@ impl CwClient for GrpcClient {
         _sender: &str,
         msg: M,
         _fees: &str,
+        _pay_amount: &str,
     ) -> Result<String, Self::Error> {
         let tm_pubkey = self.sk.public_key();
         let sender = tm_pubkey

--- a/crates/utils/cw-client/src/grpc.rs
+++ b/crates/utils/cw-client/src/grpc.rs
@@ -257,7 +257,7 @@ mod tests {
                 2000000,
                 "/* unused since we're getting the account from the sk */",
                 json!([]),
-                "0untrn"
+                "0untrn",
             )
             .await?;
         println!("{}", tx_hash);

--- a/crates/utils/cw-client/src/grpc.rs
+++ b/crates/utils/cw-client/src/grpc.rs
@@ -88,7 +88,6 @@ impl CwClient for GrpcClient {
         gas: u64,
         _sender: &str,
         msg: M,
-        _fees: &str,
         _pay_amount: &str,
     ) -> Result<String, Self::Error> {
         let tm_pubkey = self.sk.public_key();
@@ -258,7 +257,7 @@ mod tests {
                 2000000,
                 "/* unused since we're getting the account from the sk */",
                 json!([]),
-                "11000untrn",
+                "0untrn"
             )
             .await?;
         println!("{}", tx_hash);

--- a/crates/utils/cw-client/src/lib.rs
+++ b/crates/utils/cw-client/src/lib.rs
@@ -37,7 +37,6 @@ pub trait CwClient {
         gas: u64,
         sender: &str,
         msg: M,
-        fees: &str,
         pay_amount: &str,
     ) -> Result<String, Self::Error>;
 

--- a/crates/utils/cw-client/src/lib.rs
+++ b/crates/utils/cw-client/src/lib.rs
@@ -38,6 +38,7 @@ pub trait CwClient {
         sender: &str,
         msg: M,
         fees: &str,
+        pay_amount: &str,
     ) -> Result<String, Self::Error>;
 
     fn deploy<M: ToString>(


### PR DESCRIPTION
# Summary

Our CwClient trait is missing the `pay_amount` field under `tx_execute`. 

This missing field is necessary for running cycles demo3, so this PR adds it in. 

Note: the field is not yet utilized in the pure rust trait impl. 