### PR TITLE
fix(docs): checkout release version in getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -112,6 +112,7 @@ Now clone and build the repo:
 ```bash
 git clone ssh://git@github.com/informalsystems/cycles-quartz
 cd cycles-quartz
+git checkout v0.1.0             # or latest release, check `git tag --sort=-v:refname`
 cargo install --path crates/cli
 ```
 


### PR DESCRIPTION
This PR directs users to checkout the `v0.1.0` release version of quartz in getting_started.md. (the quick start instructions will fail otherwise) 