### PR TITLE
Fix: Update on getting_started / tcbinfo

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -486,10 +486,18 @@ export DCAP_CONTRACT=neutron18f3xu4yazfqr48wla9dwr7arn8wfm57qfw8ll6y02qsgmftpft6
 export ADMIN_SK=ffc4d3c9119e9e8263de08c0f6e2368ac5c2dacecfeb393f6813da7d178873d2
 cd examples/transfers
 
+# retrieve the FMSPC from your machine
+quartz print-fmspc
+
+# export it
+export FMSPC=YOUR MACHINE FMSPC HERE  // e.g. 00606A000000
+
+# you might want to update the tcbinfo contract you can follow the steps following [this guide from line 32 ](./tcbinfo_and_verifier.md).
+
 # copy the neutron testnet config file to the default quartz.toml file, so we connect to the right nodes
 cp quartz.neutron_pion-1.toml quartz.toml
 quartz enclave build
-quartz enclave start  --fmspc "00906ED50000" --tcbinfo-contract $TCBINFO_CONTRACT --dcap-verifier-contract $DCAP_CONTRACT --unsafe-trust-latest
+quartz enclave start  --fmspc $FMSPC --tcbinfo-contract $TCBINFO_CONTRACT --dcap-verifier-contract $DCAP_CONTRACT --unsafe-trust-latest
 
 # build and deploy the contracts
 quartz contract build --contract-manifest "contracts/Cargo.toml"
@@ -520,7 +528,7 @@ quartz contract deploy  --contract-manifest "examples/transfers/contracts/Cargo.
 ### Other Testnets With SGX
 
 To setup on another testnet we need to deploy a `quartz-tcbinfo` contract and a
-`quartz-dcap-verifier` contract. However we recommend using the deployed contracts on neutrons public testnet for v0.1.
+`quartz-dcap-verifier` contract. However we recommend using the deployed contracts on neutron public testnet for v0.1.
 
 Instructions can be followed in [this guide](./tcbinfo_and_verifier.md).
 

--- a/docs/tcbinfo_and_verifier.md
+++ b/docs/tcbinfo_and_verifier.md
@@ -1,36 +1,43 @@
 # Deploying tcbinfo and dcap verifier on a chain
-We have deployed the `dcap-verifier-contract` and `tcbinfo-contract` on neutrons public testnet. If you need to setup your own testnet, or use another testnet, you can use this guide. However in v0.1, we recommend sticking to the contracts we deployed. Remember to set the `QUARTZ_NODE_URL` env var to your testnet. 
+We have deployed the `dcap-verifier-contract` and `tcbinfo-contract` on neutron public testnet. If you need to setup your own testnet, or use another testnet, you can use this guide. However in v0.1, we recommend sticking to the contracts we deployed. The instructions below are meant for neutron public testnet. 
+If you wish to change them, remember to:
+0. set the `QUARTZ_NODE_URL` env var to your testnet
+1. set the correct NODE_URL env var to the correct URL 
+2. change the binary to what you need e.g. neutrond -> wasmd
+3. use the correct user `--from val1` e.g. val1 -> alice / admin
+4. use the correct chain id `--chain-id "pion-1"  e.g. pion-1 -> testing
 
 ## Get the FMSPC of the host machine
 
 ```bash
-export QUOTE="/* quote generated during the handshake should work */"
-cd crates/utils/print-fmspc/
-cargo run > /dev/null
+quartz print-fmspc
 ```
 
 ## Deploying the `quartz-tcbinfo` contract
 
 1. Build and store the contract on-chain
 ```bash
+
+export NODE_URL=https://rpc-falcron.pion-1.ntrn.tech
+
 cargo run -- contract build --contract-manifest "../cosmwasm/packages/tcbinfo/Cargo.toml"
-RES=$(wasmd tx wasm store ./target/wasm32-unknown-unknown/release/tcbinfo.wasm --from alice -y --output json --chain-id "testing" --gas-prices 0.0025ucosm --gas auto --gas-adjustment 1.3)
+RES=$(neutrond --node="$NODE_URL" tx wasm store ./target/wasm32-unknown-unknown/release/tcbinfo.wasm --from val1  -y --output json --chain-id "pion-1" --gas-prices 0.0053utrn --gas auto --gas-adjustment 1.3)
 TX_HASH=$(echo $RES | jq -r '.["txhash"]')
 ```
 
 2. Instantiate the contract using Intel's root CA cert.
 ```bash
 CERT=$(sed ':a;N;$!ba;s/\n/\\n/g' ../cosmwasm/packages/quartz-tee-ra/data/root_ca.pem)
-RES=$(wasmd query tx "$TX_HASH" --output json)
+RES=$(neutrond --node="$NODE_URL" query tx "$TX_HASH" --output json)
 CODE_ID=$(echo $RES | jq -r '.logs[0].events[1].attributes[1].value')
-wasmd tx wasm instantiate "$CODE_ID" "{\"root_cert\": \"$CERT\"}" --from "alice" --label "tcbinfo" --chain-id "testing" --gas-prices 0.0025ucosm --gas auto --gas-adjustment 1.3 -y --no-admin --output json	
-TCB_CONTRACT=$(wasmd query wasm list-contract-by-code "$CODE_ID" --output json | jq -r '.contracts[0]')
+neutrond --node="$NODE_URL" tx wasm instantiate "$CODE_ID" "{\"root_cert\": \"$CERT\"}" --from "val1" --label "tcbinfo" --chain-id "pion-1" --gas-prices 0.0053untrn --gas auto --gas-adjustment 1.3 -y --no-admin --output json	
+TCB_CONTRACT=$(neutrond --node="$NODE_URL" query wasm list-contract-by-code "$CODE_ID" --output json | jq -r '.contracts[0]')
 ```
 
 3. Get the Tcbinfo for the given FMSPC.
 ```bash
-HEADERS=$(wget -q -S -O - https://api.trustedservices.intel.com/sgx/certification/v4/tcb?fmspc=00606A000000 2>&1 >/dev/null)
-TCB_INFO=$(wget -q -O - https://api.trustedservices.intel.com/sgx/certification/v4/tcb?fmspc=00606A000000)
+HEADERS=$(wget -q -S -O - https://api.trustedservices.intel.com/sgx/certification/v4/tcb?fmspc="$FMSPC" 2>&1 >/dev/null)
+TCB_INFO=$(wget -q -O - https://api.trustedservices.intel.com/sgx/certification/v4/tcb?fmspc="$FMSPC")
 export TCB_ISSUER_CERT=$(echo "$HEADERS" | 
         grep 'TCB-Info-Issuer-Chain:' | 
         sed 's/.*TCB-Info-Issuer-Chain: //' | 
@@ -49,10 +56,13 @@ echo "TCB_ISSUER_CERT:"
 echo "$TCB_ISSUER_CERT"
 ```
 
-4. Add the Tcbinfo for the given FMSPC to the contract (and test it with a query)
+4. Store it on our contract (assuming `~/.neutrond/config/client.toml` is pointing to the testnet node) 
+
 ```bash
-wasmd tx wasm execute "$TCB_CONTRACT" "{\"tcb_info\": $(echo "$TCB_INFO" | jq -Rs .), \"certificate\": \"$TCB_ISSUER_CERT\"}" --from admin --chain-id testing --gas auto --gas-adjustment 1.2 -y 
-wasmd query wasm contract-state smart "$TCB_CONTRACT" '{"get_tcb_info": {"fmspc": "00606A000000"}}'
+export TCB_CONTRACT=neutron1anj45ushmjntew7zrg5jw2rv0rwfce3nl5d655mzzg8st0qk4wjsds4wps
+
+neutrond --node="$NODE_URL" tx wasm execute "$TCB_CONTRACT" "{\"tcb_info\": $(echo "$TCB_INFO" | jq -Rs .), \"certificate\": \"$TCB_ISSUER_CERT\"}" --from val1 --chain-id pion-1 --gas 800000 --gas-adjustment 1.2  -y 
+neutrond --node="$NODE_URL" query wasm contract-state smart "$TCB_CONTRACT" "{\"get_tcb_info\": {\"fmspc\": \"${FMSPC}\"}}"
 ```
 
 ## Deploying the `quartz-dcap-verifier` contract


### PR DESCRIPTION
Following feedback coming from a user ( see issue #277) , this PR provides simpler guidance for users.

The following changes should make it easier for users to avoid getting stuck while testing on Azure SGX in the unfortunate case that they do not have the correct FMSPC and / or their FMSPC is missing / not up-to-date in the TCB_INFO contract.

 
How to get started on Real SGX on Azure + specified how to set the tcb_info on neutron testnet