### PR TITLE
style: remove clearscreen before `quartz dev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3810b5af212b013fe7302b12d86616c6c39a48e18f2e4b812a5a9e5710213791"
 dependencies = [
- "dirs 5.0.1",
+ "dirs",
  "git2",
  "terminal-prompt",
 ]
@@ -582,7 +582,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.79",
- "which 4.4.2",
+ "which",
 ]
 
 [[package]]
@@ -918,19 +918,6 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
-
-[[package]]
-name = "clearscreen"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8c93eb5f77c9050c7750e14f13ef1033a40a0aac70c6371535b6763a01438c"
-dependencies = [
- "nix 0.28.0",
- "terminfo",
- "thiserror",
- "which 6.0.3",
- "winapi",
-]
 
 [[package]]
 name = "color-eyre"
@@ -1552,31 +1539,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -3999,44 +3966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4406,13 +4335,12 @@ dependencies = [
  "cargo-generate",
  "cargo_metadata",
  "clap",
- "clearscreen",
  "color-eyre",
  "cosmrs",
  "cosmwasm-std",
  "cw-client",
  "dcap-qvl",
- "dirs 5.0.1",
+ "dirs",
  "displaydoc",
  "figment",
  "futures-util",
@@ -5444,12 +5372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5813,19 +5735,6 @@ checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "terminfo"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
-dependencies = [
- "dirs 4.0.0",
- "fnv",
- "nom",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -6532,18 +6441,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix",
- "winsafe",
-]
-
-[[package]]
 name = "widestring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6838,12 +6735,6 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wyz"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -55,7 +55,6 @@ miette = "7.2.0"
 xxhash-rust = { version = "0.8.12", features = ["xxh3"] }
 toml = "0.8.19"
 figment = { version = "0.10.19", features = ["env", "toml"] }
-clearscreen = "3.0.0"
 cargo_metadata = "0.18.1"
 serde_with = "3.10.0"
 dcap-qvl = "0.1.0"

--- a/crates/cli/src/handler/dev.rs
+++ b/crates/cli/src/handler/dev.rs
@@ -67,8 +67,6 @@ async fn dev_driver(
     while let Some(dev) = rx.recv().await {
         match dev {
             DevRebuild::Init => {
-                clearscreen::clear()?;
-                println!("{}", BANNER.yellow().bold());
                 info!("{}", "Launching quartz app...".green().bold());
 
                 // Build enclave
@@ -109,8 +107,6 @@ async fn dev_driver(
 
                     continue;
                 }
-                clearscreen::clear()?;
-                println!("{}", BANNER.yellow().bold());
                 info!("{}", "Rebuilding Enclave...".green().bold());
 
                 info!("Waiting 1 second for the enclave to shut down");
@@ -139,8 +135,6 @@ async fn dev_driver(
                     first_contract_message = false;
                     continue;
                 }
-                clearscreen::clear()?;
-                println!("{}", BANNER.yellow().bold());
                 info!("{}", "Rebuilding Contract...".green().bold());
 
                 let res = deploy_and_handshake(None, args, &config).await;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.83.0"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Removes the use of `clearscreen` before `quartz dev` runs, so that previous outputs in the terminal can still be seen. It didn't turn out to be a good design decision in practice.

Also removed the quartz banner being reprinted after enclave / contract rebuilds in `--watch` mode. Not exactly sure which way I like it for this one, but no one uses `--watch` anyway so whatever lmao.

<img width="848" alt="image" src="https://github.com/user-attachments/assets/5aa4c789-a56b-4a21-bb65-abe9ca67c2a9" />

Versus
---

<img width="858" alt="image" src="https://github.com/user-attachments/assets/2c876756-3108-44aa-9aa1-9b753ae36ae0" />
